### PR TITLE
Soften sub button glass tint

### DIFF
--- a/lovelace-bubble-room.js
+++ b/lovelace-bubble-room.js
@@ -1482,18 +1482,18 @@ var et,it;class st extends f{constructor(){super(...arguments),this.renderOption
       min-height: 0;
       color: var(--bubble-subbutton-color, #fff);
       background:
-        radial-gradient(circle at 18% 18%, var(--bubble-subbutton-glass-sheen, rgba(255, 255, 255, 0.32)), rgba(255, 255, 255, 0) 60%),
-        linear-gradient(140deg, var(--bubble-subbutton-glass-highlight, rgba(255, 255, 255, 0.22)), rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.04) 58%),
-        linear-gradient(200deg, var(--bubble-subbutton-glass-soft, rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.12)), rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.18) 82%),
-        var(--bubble-subbutton-glass-base, var(--bubble-subbutton-bg, rgba(255, 255, 255, 0.06)));
+        radial-gradient(circle at 18% 18%, var(--bubble-subbutton-glass-sheen, rgba(255, 255, 255, 0.18)), rgba(255, 255, 255, 0) 62%),
+        linear-gradient(140deg, var(--bubble-subbutton-glass-highlight, rgba(255, 255, 255, 0.09)), rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.016) 58%),
+        linear-gradient(200deg, var(--bubble-subbutton-glass-soft, rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.04)), rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.07) 82%),
+        var(--bubble-subbutton-glass-base, var(--bubble-subbutton-bg, rgba(255, 255, 255, 0.02)));
       background-blend-mode: screen, lighten, overlay, normal;
       box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.26),
-        inset 0 -1px 0 rgba(255, 255, 255, 0.08),
-        0 18px 28px var(--bubble-subbutton-glass-shadow, rgba(13, 22, 41, 0.16));
-      border: 1px solid rgba(255, 255, 255, 0.2);
-      backdrop-filter: blur(28px) saturate(160%);
-      -webkit-backdrop-filter: blur(28px) saturate(160%);
+        inset 0 1px 0 rgba(255, 255, 255, 0.14),
+        inset 0 -1px 0 rgba(255, 255, 255, 0.032),
+        0 10px 18px var(--bubble-subbutton-glass-shadow, rgba(13, 22, 41, 0.1));
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      backdrop-filter: blur(22px);
+      -webkit-backdrop-filter: blur(22px);
       transition: background 0.35s ease, box-shadow 0.35s ease, transform 0.18s ease;
       isolation: isolate;
     }
@@ -1509,16 +1509,16 @@ var et,it;class st extends f{constructor(){super(...arguments),this.renderOption
     .sub-button:active {
       transform: scale(0.96);
       box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.32),
-        inset 0 -1px 0 rgba(255, 255, 255, 0.12),
-        0 8px 18px var(--bubble-subbutton-glass-shadow-active, rgba(13, 22, 41, 0.2));
+        inset 0 1px 0 rgba(255, 255, 255, 0.22),
+        inset 0 -1px 0 rgba(255, 255, 255, 0.05),
+        0 6px 14px var(--bubble-subbutton-glass-shadow-active, rgba(13, 22, 41, 0.14));
     }
 
     .sub-button:hover {
       box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.32),
-        inset 0 -1px 0 rgba(255, 255, 255, 0.12),
-        0 22px 32px var(--bubble-subbutton-glass-shadow-hover, rgba(13, 22, 41, 0.2));
+        inset 0 1px 0 rgba(255, 255, 255, 0.2),
+        inset 0 -1px 0 rgba(255, 255, 255, 0.06),
+        0 16px 26px var(--bubble-subbutton-glass-shadow-hover, rgba(13, 22, 41, 0.13));
     }
 
     .sub-button::before,
@@ -1531,19 +1531,19 @@ var et,it;class st extends f{constructor(){super(...arguments),this.renderOption
     }
 
     .sub-button::before {
-      background: radial-gradient(circle at 20% -10%, var(--bubble-subbutton-glass-sheen, rgba(255, 255, 255, 0.38)), rgba(255, 255, 255, 0));
-      opacity: 0.42;
+      background: radial-gradient(circle at 20% -10%, var(--bubble-subbutton-glass-sheen, rgba(255, 255, 255, 0.32)), rgba(255, 255, 255, 0));
+      opacity: 0.24;
       transform: translateY(-6%);
     }
 
     .sub-button::after {
       background: linear-gradient(205deg, var(--bubble-subbutton-glass-accent, rgba(255, 255, 255, 0.05)), rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0) 60%);
-      opacity: 0.2;
+      opacity: 0.1;
       mix-blend-mode: soft-light;
     }
 
     .sub-button:hover::before {
-      opacity: 0.8;
+      opacity: 0.5;
     }
 
     /* 👇 Icona scalabile al contenitore */
@@ -1552,8 +1552,8 @@ var et,it;class st extends f{constructor(){super(...arguments),this.renderOption
       height: 80%;
       color: inherit;
       filter:
-        drop-shadow(0 8px 16px rgba(var(--bubble-subbutton-glass-shadow-rgb, 13, 22, 41), 0.22))
-        drop-shadow(0 1px 0 rgba(255, 255, 255, 0.32));
+        drop-shadow(0 6px 12px rgba(var(--bubble-subbutton-glass-shadow-rgb, 13, 22, 41), 0.14))
+        drop-shadow(0 1px 0 rgba(255, 255, 255, 0.24));
     }
     
     /* 👇 (Opzionale) Rende l'icona SVG responsiva */
@@ -1567,7 +1567,7 @@ var et,it;class st extends f{constructor(){super(...arguments),this.renderOption
     }
   `;render(){return I`
       <div class="container">
-        ${this.subbuttons.map((t,e)=>{const i=t.active?t.colorOn:t.colorOff,s=t.active?t.iconOn:t.iconOff,n=this._computeGlassColors(i),o=[`--bubble-subbutton-color:${s}`];n?(o.push(`--bubble-subbutton-bg:${n.fill}`),o.push(`--bubble-subbutton-glass-base:${n.base}`),o.push(`--bubble-subbutton-glass-highlight:${n.highlight}`),o.push(`--bubble-subbutton-glass-soft:${n.soft}`),o.push(`--bubble-subbutton-glass-sheen:${n.sheen}`),o.push(`--bubble-subbutton-glass-accent:${n.accent}`),o.push(`--bubble-subbutton-tint:${n.rgb}`),o.push(`--bubble-subbutton-glass-shadow:${n.shadow}`),o.push(`--bubble-subbutton-glass-shadow-hover:${n.shadowHover}`),o.push(`--bubble-subbutton-glass-shadow-active:${n.shadowActive}`),o.push(`--bubble-subbutton-glass-shadow-rgb:${n.shadowRgb}`)):o.push(`--bubble-subbutton-bg:${i}`);const a=o.join(";");return I`
+        ${this.subbuttons.map((t,e)=>{const i=t.active?t.colorOn:t.colorOff,s=t.active?t.iconOn:t.iconOff,n=this._computeGlassColors(i),o=[`--bubble-subbutton-color:${s}`];n?(o.push(`--bubble-subbutton-bg:${n.surface}`),o.push(`--bubble-subbutton-glass-base:${n.base}`),o.push(`--bubble-subbutton-glass-highlight:${n.highlight}`),o.push(`--bubble-subbutton-glass-soft:${n.soft}`),o.push(`--bubble-subbutton-glass-sheen:${n.sheen}`),o.push(`--bubble-subbutton-glass-accent:${n.accent}`),o.push(`--bubble-subbutton-tint:${n.rgb}`),o.push(`--bubble-subbutton-glass-shadow:${n.shadow}`),o.push(`--bubble-subbutton-glass-shadow-hover:${n.shadowHover}`),o.push(`--bubble-subbutton-glass-shadow-active:${n.shadowActive}`),o.push(`--bubble-subbutton-glass-shadow-rgb:${n.shadowRgb}`)):o.push(`--bubble-subbutton-bg:${i}`);const a=o.join(";");return I`
             <div
               class="sub-button"
               style="${a}"
@@ -1580,7 +1580,7 @@ var et,it;class st extends f{constructor(){super(...arguments),this.renderOption
             </div>
           `})}
       </div>
-    `}_onDown(t){this._holdFired=!1,this._currentIndex=t,this._holdTimer=window.setTimeout(()=>{this._holdFired=!0,this._fireHassAction(t,"hold")},this._holdThreshold)}_onUp(t){this._clearHoldTimer(),this._holdFired||this._currentIndex!==t||this._fireHassAction(t,"tap")}_clearHoldTimer(){this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)}_computeGlassColors(t){const e=this._colorToRgb(t);if(!e)return null;const{r:i,g:s,b:n}=e,o=`${i}, ${s}, ${n}`,a=this._mixWithWhite(e,.6),r=`${a.r}, ${a.g}, ${a.b}`,l=`linear-gradient(165deg, rgba(${r}, 0.36), rgba(${o}, 0.12))`,c=`rgba(${r}, 0.26)`,d=`rgba(${r}, 0.18)`,h=`rgba(${r}, 0.12)`,u=`rgba(${r}, 0.38)`,p=.28,b=`${Math.max(0,Math.round(i*p))}, ${Math.max(0,Math.round(s*p))}, ${Math.max(0,Math.round(n*p))}`;return{rgb:o,fill:u,base:l,highlight:c,soft:d,sheen:"rgba(255, 255, 255, 0.42)",accent:h,shadow:`rgba(${b}, 0.16)`,shadowHover:`rgba(${b}, 0.24)`,shadowActive:`rgba(${b}, 0.2)`,shadowRgb:b}}_mixWithWhite({r:t,g:e,b:i},s=.5){const n=Math.min(Math.max(s,0),1),o=t=>Math.round(t+(255-t)*n);return{r:o(t),g:o(e),b:o(i)}}_colorToRgb(t){if(!t||"string"!=typeof t||t.startsWith("var("))return null;if("undefined"==typeof document)return null;if(!Ut._colorCanvas){const t=document.createElement("canvas");t.width=t.height=1,Ut._colorCanvas=t,Ut._colorCtx=t.getContext("2d",{willReadFrequently:!0})||t.getContext("2d")}const e=Ut._colorCtx;if(!e)return null;try{e.fillStyle="#000",e.fillStyle=t}catch(t){return null}const i=e.fillStyle;e.clearRect(0,0,1,1),e.fillStyle=i,e.fillRect(0,0,1,1);const s=e.getImageData(0,0,1,1).data;return{r:s[0],g:s[1],b:s[2],a:s[3]/255}}_fireHassAction(t,e){const i=this.subbuttons?.[t];if(!i||!i.entity_id)return;const s={entity:i.entity_id,tap_action:i.tap_action||{action:"toggle"},hold_action:i.hold_action||{action:"more-info"}},n=new Event("hass-action",{bubbles:!0,composed:!0});n.detail={config:s,action:e},this.dispatchEvent(n)}}Ut._colorCanvas=null,Ut._colorCtx=null,customElements.define("bubble-subbutton",Ut);class Ht extends st{static properties={hass:{type:Object},name:{type:String},area:{type:String},config:{type:Object},container:{type:Object},fitMode:{type:String},stretchY:{type:Number}};constructor(){super(),this.name="",this.fitMode="height",this.stretchY=1.12,this._raf=null,this._resizeObs=null,this._lastScale=null,this._lastBox=null}_ensureFonts(){const t=this.renderRoot||this.shadowRoot;if(!t)return;if(t.querySelector('link[data-bubble-fonts="1"]'))return;const e=document.createElement("link");e.rel="preconnect",e.href="https://fonts.gstatic.com",e.crossOrigin="anonymous",e.setAttribute("data-bubble-fonts","1"),t.appendChild(e);const i=document.createElement("link");i.rel="stylesheet",i.href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Oswald:wght@400;700&family=Roboto+Condensed:wght@400;700&display=swap",i.setAttribute("data-bubble-fonts","1"),i.addEventListener("load",()=>{requestAnimationFrame(()=>this._scheduleScale())}),t.appendChild(i)}firstUpdated(){this._ensureFonts(),this._scheduleScale(),this._resizeObs=new ResizeObserver(t=>{const e=t[0];let i=0,s=0;if(e?.contentBoxSize){const t=Array.isArray(e.contentBoxSize)?e.contentBoxSize[0]:e.contentBoxSize;i=Math.round(t.inlineSize),s=Math.round(t.blockSize)}else{const t=this.getBoundingClientRect();i=Math.round(t.width),s=Math.round(t.height)}(!this._lastBox||Math.abs(i-this._lastBox.w)>2||Math.abs(s-this._lastBox.h)>2)&&(this._lastBox={w:i,h:s},this._scheduleScale())}),this._resizeObs.observe(this),window.addEventListener("resize",this._scheduleScale,{passive:!0})}updated(t){(t.has("name")||t.has("config")||t.has("container")||t.has("fitMode")||t.has("stretchY"))&&this._scheduleScale()}disconnectedCallback(){super.disconnectedCallback(),this._resizeObs?.disconnect(),window.removeEventListener("resize",this._scheduleScale)}_scheduleScale=()=>{this._raf||(this._raf=requestAnimationFrame(()=>{this._raf=null,this._autoScaleFont()}))};_autoScaleFont(){const t=this.renderRoot.querySelector(".bubble-name"),e=this.container||this.parentElement||this;if(!t||!e)return;const i=this.name??"",s=Math.max(0,Math.round(e.clientWidth)),n=Math.max(0,Math.round(e.clientHeight));if(this._lastScale&&this._lastScale.text===i&&this._lastScale.w===s&&this._lastScale.h===n&&this._lastScale.fitMode===this.fitMode&&this._lastScale.stretchY===this.stretchY)return;this._resizeObs.disconnect(),t.style.fontSize="10px",t.style.transform="none";const o=240;let a;if("height"===this.fitMode){let e=8,i=o;for(let s=0;s<9&&e<=i;s++){const s=e+i>>1;t.style.fontSize=`${s}px`;t.scrollHeight<=n?e=s+1:i=s-1}a=Math.max(8,Math.min(o,i)),t.style.fontSize=`${a}px`;const r=t.scrollWidth;if(r>s&&r>0){const t=s/r;a=Math.floor(a*t)}}else{let e=8,i=o;for(let o=0;o<8&&e<=i;o++){const o=e+i>>1;t.style.fontSize=`${o}px`,t.scrollWidth<=s&&t.scrollHeight<=n?e=o+1:i=o-1}a=Math.max(8,Math.min(o,i))}t.style.fontSize=`${a}px`,this.stretchY&&1!==this.stretchY?(t.style.transform=`scaleY(${this.stretchY})`,t.style.transformOrigin="center"):t.style.transform="none",this._lastScale={text:i,w:s,h:n,fitMode:this.fitMode,stretchY:this.stretchY},this._resizeObs.observe(this)}render(){return I`
+    `}_onDown(t){this._holdFired=!1,this._currentIndex=t,this._holdTimer=window.setTimeout(()=>{this._holdFired=!0,this._fireHassAction(t,"hold")},this._holdThreshold)}_onUp(t){this._clearHoldTimer(),this._holdFired||this._currentIndex!==t||this._fireHassAction(t,"tap")}_clearHoldTimer(){this._holdTimer&&(clearTimeout(this._holdTimer),this._holdTimer=null)}_computeGlassColors(t){const e=this._colorToRgb(t);if(!e)return null;const{r:i,g:s,b:n}=e,o=`${i}, ${s}, ${n}`,a=this._mixWithWhite(e,.65),r=`${a.r}, ${a.g}, ${a.b}`,l=`rgba(${r}, 0.08)`,c=`rgba(${r}, 0.06)`,d=`rgba(${r}, 0.12)`,h=`rgba(${r}, 0.07)`,u=`rgba(${r}, 0.05)`,p=`${Math.max(0,Math.round(.2*i))}, ${Math.max(0,Math.round(.2*s))}, ${Math.max(0,Math.round(.2*n))}`;return{rgb:o,surface:l,base:c,highlight:d,soft:h,sheen:"rgba(255, 255, 255, 0.24)",accent:u,shadow:`rgba(${p}, 0.1)`,shadowHover:`rgba(${p}, 0.14)`,shadowActive:`rgba(${p}, 0.12)`,shadowRgb:p}}_mixWithWhite({r:t,g:e,b:i},s=.5){const n=Math.min(Math.max(s,0),1),o=t=>Math.round(t+(255-t)*n);return{r:o(t),g:o(e),b:o(i)}}_colorToRgb(t){if(!t||"string"!=typeof t||t.startsWith("var("))return null;if("undefined"==typeof document)return null;if(!Ut._colorCanvas){const t=document.createElement("canvas");t.width=t.height=1,Ut._colorCanvas=t,Ut._colorCtx=t.getContext("2d",{willReadFrequently:!0})||t.getContext("2d")}const e=Ut._colorCtx;if(!e)return null;try{e.fillStyle="#000",e.fillStyle=t}catch(t){return null}const i=e.fillStyle;e.clearRect(0,0,1,1),e.fillStyle=i,e.fillRect(0,0,1,1);const s=e.getImageData(0,0,1,1).data;return{r:s[0],g:s[1],b:s[2],a:s[3]/255}}_fireHassAction(t,e){const i=this.subbuttons?.[t];if(!i||!i.entity_id)return;const s={entity:i.entity_id,tap_action:i.tap_action||{action:"toggle"},hold_action:i.hold_action||{action:"more-info"}},n=new Event("hass-action",{bubbles:!0,composed:!0});n.detail={config:s,action:e},this.dispatchEvent(n)}}Ut._colorCanvas=null,Ut._colorCtx=null,customElements.define("bubble-subbutton",Ut);class Ht extends st{static properties={hass:{type:Object},name:{type:String},area:{type:String},config:{type:Object},container:{type:Object},fitMode:{type:String},stretchY:{type:Number}};constructor(){super(),this.name="",this.fitMode="height",this.stretchY=1.12,this._raf=null,this._resizeObs=null,this._lastScale=null,this._lastBox=null}_ensureFonts(){const t=this.renderRoot||this.shadowRoot;if(!t)return;if(t.querySelector('link[data-bubble-fonts="1"]'))return;const e=document.createElement("link");e.rel="preconnect",e.href="https://fonts.gstatic.com",e.crossOrigin="anonymous",e.setAttribute("data-bubble-fonts","1"),t.appendChild(e);const i=document.createElement("link");i.rel="stylesheet",i.href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Oswald:wght@400;700&family=Roboto+Condensed:wght@400;700&display=swap",i.setAttribute("data-bubble-fonts","1"),i.addEventListener("load",()=>{requestAnimationFrame(()=>this._scheduleScale())}),t.appendChild(i)}firstUpdated(){this._ensureFonts(),this._scheduleScale(),this._resizeObs=new ResizeObserver(t=>{const e=t[0];let i=0,s=0;if(e?.contentBoxSize){const t=Array.isArray(e.contentBoxSize)?e.contentBoxSize[0]:e.contentBoxSize;i=Math.round(t.inlineSize),s=Math.round(t.blockSize)}else{const t=this.getBoundingClientRect();i=Math.round(t.width),s=Math.round(t.height)}(!this._lastBox||Math.abs(i-this._lastBox.w)>2||Math.abs(s-this._lastBox.h)>2)&&(this._lastBox={w:i,h:s},this._scheduleScale())}),this._resizeObs.observe(this),window.addEventListener("resize",this._scheduleScale,{passive:!0})}updated(t){(t.has("name")||t.has("config")||t.has("container")||t.has("fitMode")||t.has("stretchY"))&&this._scheduleScale()}disconnectedCallback(){super.disconnectedCallback(),this._resizeObs?.disconnect(),window.removeEventListener("resize",this._scheduleScale)}_scheduleScale=()=>{this._raf||(this._raf=requestAnimationFrame(()=>{this._raf=null,this._autoScaleFont()}))};_autoScaleFont(){const t=this.renderRoot.querySelector(".bubble-name"),e=this.container||this.parentElement||this;if(!t||!e)return;const i=this.name??"",s=Math.max(0,Math.round(e.clientWidth)),n=Math.max(0,Math.round(e.clientHeight));if(this._lastScale&&this._lastScale.text===i&&this._lastScale.w===s&&this._lastScale.h===n&&this._lastScale.fitMode===this.fitMode&&this._lastScale.stretchY===this.stretchY)return;this._resizeObs.disconnect(),t.style.fontSize="10px",t.style.transform="none";const o=240;let a;if("height"===this.fitMode){let e=8,i=o;for(let s=0;s<9&&e<=i;s++){const s=e+i>>1;t.style.fontSize=`${s}px`;t.scrollHeight<=n?e=s+1:i=s-1}a=Math.max(8,Math.min(o,i)),t.style.fontSize=`${a}px`;const r=t.scrollWidth;if(r>s&&r>0){const t=s/r;a=Math.floor(a*t)}}else{let e=8,i=o;for(let o=0;o<8&&e<=i;o++){const o=e+i>>1;t.style.fontSize=`${o}px`,t.scrollWidth<=s&&t.scrollHeight<=n?e=o+1:i=o-1}a=Math.max(8,Math.min(o,i))}t.style.fontSize=`${a}px`,this.stretchY&&1!==this.stretchY?(t.style.transform=`scaleY(${this.stretchY})`,t.style.transformOrigin="center"):t.style.transform="none",this._lastScale={text:i,w:s,h:n,fitMode:this.fitMode,stretchY:this.stretchY},this._resizeObs.observe(this)}render(){return I`
       <div class="bubble-name" title="${this.name||""}">
         ${this.name}
       </div>

--- a/src/components/BubbleSubButton.js
+++ b/src/components/BubbleSubButton.js
@@ -45,18 +45,18 @@ export class BubbleSubButton extends LitElement {
       min-height: 0;
       color: var(--bubble-subbutton-color, #fff);
       background:
-        radial-gradient(circle at 18% 18%, var(--bubble-subbutton-glass-sheen, rgba(255, 255, 255, 0.32)), rgba(255, 255, 255, 0) 60%),
-        linear-gradient(140deg, var(--bubble-subbutton-glass-highlight, rgba(255, 255, 255, 0.22)), rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.04) 58%),
-        linear-gradient(200deg, var(--bubble-subbutton-glass-soft, rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.12)), rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.18) 82%),
-        var(--bubble-subbutton-glass-base, var(--bubble-subbutton-bg, rgba(255, 255, 255, 0.06)));
+        radial-gradient(circle at 18% 18%, var(--bubble-subbutton-glass-sheen, rgba(255, 255, 255, 0.18)), rgba(255, 255, 255, 0) 62%),
+        linear-gradient(140deg, var(--bubble-subbutton-glass-highlight, rgba(255, 255, 255, 0.09)), rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.016) 58%),
+        linear-gradient(200deg, var(--bubble-subbutton-glass-soft, rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.04)), rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0.07) 82%),
+        var(--bubble-subbutton-glass-base, var(--bubble-subbutton-bg, rgba(255, 255, 255, 0.02)));
       background-blend-mode: screen, lighten, overlay, normal;
       box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.26),
-        inset 0 -1px 0 rgba(255, 255, 255, 0.08),
-        0 18px 28px var(--bubble-subbutton-glass-shadow, rgba(13, 22, 41, 0.16));
-      border: 1px solid rgba(255, 255, 255, 0.2);
-      backdrop-filter: blur(28px) saturate(160%);
-      -webkit-backdrop-filter: blur(28px) saturate(160%);
+        inset 0 1px 0 rgba(255, 255, 255, 0.14),
+        inset 0 -1px 0 rgba(255, 255, 255, 0.032),
+        0 10px 18px var(--bubble-subbutton-glass-shadow, rgba(13, 22, 41, 0.1));
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      backdrop-filter: blur(22px);
+      -webkit-backdrop-filter: blur(22px);
       transition: background 0.35s ease, box-shadow 0.35s ease, transform 0.18s ease;
       isolation: isolate;
     }
@@ -72,16 +72,16 @@ export class BubbleSubButton extends LitElement {
     .sub-button:active {
       transform: scale(0.96);
       box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.32),
-        inset 0 -1px 0 rgba(255, 255, 255, 0.12),
-        0 8px 18px var(--bubble-subbutton-glass-shadow-active, rgba(13, 22, 41, 0.2));
+        inset 0 1px 0 rgba(255, 255, 255, 0.22),
+        inset 0 -1px 0 rgba(255, 255, 255, 0.05),
+        0 6px 14px var(--bubble-subbutton-glass-shadow-active, rgba(13, 22, 41, 0.14));
     }
 
     .sub-button:hover {
       box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.32),
-        inset 0 -1px 0 rgba(255, 255, 255, 0.12),
-        0 22px 32px var(--bubble-subbutton-glass-shadow-hover, rgba(13, 22, 41, 0.2));
+        inset 0 1px 0 rgba(255, 255, 255, 0.2),
+        inset 0 -1px 0 rgba(255, 255, 255, 0.06),
+        0 16px 26px var(--bubble-subbutton-glass-shadow-hover, rgba(13, 22, 41, 0.13));
     }
 
     .sub-button::before,
@@ -94,19 +94,19 @@ export class BubbleSubButton extends LitElement {
     }
 
     .sub-button::before {
-      background: radial-gradient(circle at 20% -10%, var(--bubble-subbutton-glass-sheen, rgba(255, 255, 255, 0.38)), rgba(255, 255, 255, 0));
-      opacity: 0.42;
+      background: radial-gradient(circle at 20% -10%, var(--bubble-subbutton-glass-sheen, rgba(255, 255, 255, 0.32)), rgba(255, 255, 255, 0));
+      opacity: 0.24;
       transform: translateY(-6%);
     }
 
     .sub-button::after {
       background: linear-gradient(205deg, var(--bubble-subbutton-glass-accent, rgba(255, 255, 255, 0.05)), rgba(var(--bubble-subbutton-tint, 255, 255, 255), 0) 60%);
-      opacity: 0.2;
+      opacity: 0.1;
       mix-blend-mode: soft-light;
     }
 
     .sub-button:hover::before {
-      opacity: 0.8;
+      opacity: 0.5;
     }
 
     /* 👇 Icona scalabile al contenitore */
@@ -115,8 +115,8 @@ export class BubbleSubButton extends LitElement {
       height: 80%;
       color: inherit;
       filter:
-        drop-shadow(0 8px 16px rgba(var(--bubble-subbutton-glass-shadow-rgb, 13, 22, 41), 0.22))
-        drop-shadow(0 1px 0 rgba(255, 255, 255, 0.32));
+        drop-shadow(0 6px 12px rgba(var(--bubble-subbutton-glass-shadow-rgb, 13, 22, 41), 0.14))
+        drop-shadow(0 1px 0 rgba(255, 255, 255, 0.24));
     }
     
     /* 👇 (Opzionale) Rende l'icona SVG responsiva */
@@ -141,7 +141,7 @@ export class BubbleSubButton extends LitElement {
           const styleVars = [`--bubble-subbutton-color:${color}`];
 
           if (glass) {
-            styleVars.push(`--bubble-subbutton-bg:${glass.fill}`);
+            styleVars.push(`--bubble-subbutton-bg:${glass.surface}`);
             styleVars.push(`--bubble-subbutton-glass-base:${glass.base}`);
             styleVars.push(`--bubble-subbutton-glass-highlight:${glass.highlight}`);
             styleVars.push(`--bubble-subbutton-glass-soft:${glass.soft}`);
@@ -204,30 +204,29 @@ export class BubbleSubButton extends LitElement {
 
     const { r, g, b } = rgb;
     const rgbString = `${r}, ${g}, ${b}`;
-
-    const softened = this._mixWithWhite(rgb, 0.6);
+    const softened = this._mixWithWhite(rgb, 0.65);
     const softenedString = `${softened.r}, ${softened.g}, ${softened.b}`;
 
-    const base = `linear-gradient(165deg, rgba(${softenedString}, 0.36), rgba(${rgbString}, 0.12))`;
-    const highlight = `rgba(${softenedString}, 0.26)`;
-    const soft = `rgba(${softenedString}, 0.18)`;
-    const sheen = `rgba(255, 255, 255, 0.42)`;
-    const accent = `rgba(${softenedString}, 0.12)`;
-    const fill = `rgba(${softenedString}, 0.38)`;
+    const surface = `rgba(${softenedString}, 0.08)`;
+    const base = `rgba(${softenedString}, 0.06)`;
+    const highlight = `rgba(${softenedString}, 0.12)`;
+    const soft = `rgba(${softenedString}, 0.07)`;
+    const sheen = `rgba(255, 255, 255, 0.24)`;
+    const accent = `rgba(${softenedString}, 0.05)`;
 
-    const shadowFactor = 0.28;
+    const shadowFactor = 0.2;
     const shadowR = Math.max(0, Math.round(r * shadowFactor));
     const shadowG = Math.max(0, Math.round(g * shadowFactor));
     const shadowB = Math.max(0, Math.round(b * shadowFactor));
     const shadowRgb = `${shadowR}, ${shadowG}, ${shadowB}`;
 
-    const shadow = `rgba(${shadowRgb}, 0.16)`;
-    const shadowHover = `rgba(${shadowRgb}, 0.24)`;
-    const shadowActive = `rgba(${shadowRgb}, 0.2)`;
+    const shadow = `rgba(${shadowRgb}, 0.1)`;
+    const shadowHover = `rgba(${shadowRgb}, 0.14)`;
+    const shadowActive = `rgba(${shadowRgb}, 0.12)`;
 
     return {
       rgb: rgbString,
-      fill,
+      surface,
       base,
       highlight,
       soft,


### PR DESCRIPTION
## Summary
- restore the previous glass-styled sub button surface while reducing the tint opacity for a subtler appearance
- lighten computed color variables by mixing with white and lower alpha values to increase transparency
- rebuild the distribution bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc6ad851e883268644e19a23e868a1